### PR TITLE
clean missing files after post message

### DIFF
--- a/jobs/committed/1.fetchJSON.js
+++ b/jobs/committed/1.fetchJSON.js
@@ -59,7 +59,7 @@ fn(state => {
       .post({ url, data })(state)
       .then(() => {
         console.log(`Posted missing to OpenFn Inbox.\n`);
-        return { ...state, references: [], data: {} };
+        return { ...state, references: [], data: {}, missingFiles: [] };
       });
   }
   return state;

--- a/jobs/committed/1.fetchJSON_Donors.js
+++ b/jobs/committed/1.fetchJSON_Donors.js
@@ -45,7 +45,7 @@ fn(state => {
       .post({ url, data })(state)
       .then(() => {
         console.log(`Posted missing to OpenFn Inbox.\n`);
-        return { ...state, references: [], data: {} };
+        return { ...state, references: [], data: {}, missingFiles: [] };
       });
   }
   return state;
@@ -124,6 +124,7 @@ each(
         console.log('Duplicate rows detected in Committed Giving:');
         duplicates.forEach(d => console.log(d));
         console.log('End of duplicates rows.');
+
         throw new Error(`Aborting run; duplicates detected.`);
       }
       return { configuration, references: [], data: {} };


### PR DESCRIPTION
### Summary
Cleaning up `state.missingFiles` after we post to inbox. This makes sure that we don't have missingFiles in state, next time the job run so that email alert will only be triggered when we have new missing files 
#138 