### PR TITLE
remove missingFiles from final state

### DIFF
--- a/jobs/committed/1.fetchJSON.js
+++ b/jobs/committed/1.fetchJSON.js
@@ -59,7 +59,7 @@ fn(state => {
       .post({ url, data })(state)
       .then(() => {
         console.log(`Posted missing to OpenFn Inbox.\n`);
-        return { ...state, references: [], data: {} };
+        return { ...state, references: [], data: {}, missingFiles: [] };
       });
   }
   return state;

--- a/jobs/committed/1.fetchJSON_Donors.js
+++ b/jobs/committed/1.fetchJSON_Donors.js
@@ -45,7 +45,7 @@ fn(state => {
       .post({ url, data })(state)
       .then(() => {
         console.log(`Posted missing to OpenFn Inbox.\n`);
-        return { ...state, references: [], data: {} };
+        return { ...state, references: [], data: {}, missingFiles: [] };
       });
   }
   return state;


### PR DESCRIPTION
### Summary
Remove `missingFiles` from final state so that it does not trigger email alert next time the job run 
Ref #138 